### PR TITLE
Fixed wrong order of download shapefiles step

### DIFF
--- a/afvalophaalgebieden/docker-import-db.sh
+++ b/afvalophaalgebieden/docker-import-db.sh
@@ -6,10 +6,10 @@ set -x   # log every command.
 
 source docker-wait.sh
 
-python check_db.py /data
-
 # download files
 python download_files_from_dcatd.py qji2W_HBpWUWyg /data
+
+python check_db.py /data
 
 # load data in database
 python run_import.py /data


### PR DESCRIPTION
The download shapefiles step was put in the wrong order of the docker-import script, which failed the jenkins-import used in the Import_Afvalophaalgebieden_DEV Job.