### PR TITLE
[AB#28027] Remove Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-# Docs: https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Dependabot should send security-related PRs [by default](https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/configuring-notifications-for-vulnerable-dependencies). Enabling it for all updates gives too much noise.